### PR TITLE
fix: add fallback_scrape_protocol

### DIFF
--- a/scenario-01/prometheus.yml
+++ b/scenario-01/prometheus.yml
@@ -1,11 +1,13 @@
 scrape_configs:
   - job_name: service-a
     scrape_interval: 4s
+    fallback_scrape_protocol: PrometheusText0.0.4
     static_configs:
       - targets: ['service-a:5000']
 
   - job_name: service-b
     scrape_interval: 4s
+    fallback_scrape_protocol: PrometheusText0.0.4
     static_configs:
       - targets: ['service-b:5001']
 


### PR DESCRIPTION
Prometheus v3 is more strict concerning the Content-Type header received when scraping. Prometheus v2 would default to the standard Prometheus text protocol if the target being scraped did not specify a Content-Type header or if the header was unparsable or unrecognised. This could lead to incorrect data being parsed in the scrape. Prometheus v3 will now fail the scrape in such cases.If a scrape target is not providing the correct Content-Type header the fallback protocol can be specified using the fallback_scrape_protocol parameter. See Prometheus scrape_config documentation.